### PR TITLE
Fix scroll to top

### DIFF
--- a/demo/src/components/ScrollToTop.js
+++ b/demo/src/components/ScrollToTop.js
@@ -1,0 +1,22 @@
+import {Component} from 'react';
+import {withRouter} from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  location: PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired
+};
+
+export default withRouter(ScrollToTop);

--- a/demo/src/routes.js
+++ b/demo/src/routes.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import {BrowserRouter} from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop'
 
 import App from './App';
 
 const Router = () => (
-  <BrowserRouter onUpdate={() => window.scrollTo(0, 0)}>
-    <App />
+  <BrowserRouter>
+    <ScrollToTop>
+      <App />
+    </ScrollToTop>
   </BrowserRouter>
 );
 


### PR DESCRIPTION
As the `onUpdate=` has been removed in `react-router-dom` v4. The scroll to top feature of router navigation doesn't work. This makes bad experience in long content switching. The PR fixed this bug.

Reference:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md