### PR TITLE
fix comment typo in src/seeds/Modal/Modal.js line 21

### DIFF
--- a/src/seeds/Modal/Modal.js
+++ b/src/seeds/Modal/Modal.js
@@ -18,7 +18,7 @@ class Modal extends React.Component {
      * Custom component style
      *
      * @cn
-     * Custom button component class name
+     * 自定义组件按钮样式
      */
     style: PropTypes.object,
     /**


### PR DESCRIPTION
修复了 src 中 cn 注释不是中文的 typo