### PR TITLE
fix: clear timer before 'Modal' component unmount to avoid emitting '…

### DIFF
--- a/src/seeds/Modal/Modal.js
+++ b/src/seeds/Modal/Modal.js
@@ -159,6 +159,10 @@ class Modal extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.timer && clearTimeout(this.timer);
+  }
+
   setContainerRef = c => {
     this.container = c;
   };


### PR DESCRIPTION
…undefined' error when access to ref 'style'